### PR TITLE
Fixes #45

### DIFF
--- a/STM32F412XX_FLASH.ld
+++ b/STM32F412XX_FLASH.ld
@@ -154,6 +154,7 @@ SECTIONS
   {
     . = ALIGN(4);
     FILL(0x00)
+    *(.program_data_block)
     . = ALIGN(4);
   } > RESERVED 
 


### PR DESCRIPTION
Er was een oude linkefile toegevoegd. Dat is nu gecorrigeerd. De program_data_block wordt nu netjes geladen in het gereserveerde geheugen.