### PR TITLE
Update van de internal sensors

### DIFF
--- a/Core/Inc/main.h
+++ b/Core/Inc/main.h
@@ -46,8 +46,7 @@ extern "C" {
 
 /* Exported macro ------------------------------------------------------------*/
 /* USER CODE BEGIN EM */
-#define ADC_SAMPLES 10
-extern uint16_t adc_buffer[ADC_SAMPLES * 2 * 2];
+extern uint16_t adc_buffer[2];
 /* USER CODE END EM */
 
 /* Exported functions prototypes ---------------------------------------------*/

--- a/Core/Src/adc.c
+++ b/Core/Src/adc.c
@@ -62,7 +62,7 @@ void MX_ADC1_Init(void)
 
   /** Configure for the selected ADC regular channel its corresponding rank in the sequencer and its sample time.
   */
-  sConfig.Channel = ADC_CHANNEL_TEMPSENSOR;
+  sConfig.Channel = ADC_CHANNEL_VREFINT;
   sConfig.Rank = 1;
   sConfig.SamplingTime = ADC_SAMPLETIME_84CYCLES;
   if (HAL_ADC_ConfigChannel(&hadc1, &sConfig) != HAL_OK)
@@ -72,7 +72,7 @@ void MX_ADC1_Init(void)
 
   /** Configure for the selected ADC regular channel its corresponding rank in the sequencer and its sample time.
   */
-  sConfig.Channel = ADC_CHANNEL_VREFINT;
+  sConfig.Channel = ADC_CHANNEL_TEMPSENSOR;
   sConfig.Rank = 2;
   if (HAL_ADC_ConfigChannel(&hadc1, &sConfig) != HAL_OK)
   {

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -114,7 +114,7 @@ int main(void)
   /* USER CODE BEGIN 2 */
 
   HAL_TIM_Base_Start_IT(&htim3);
-  HAL_ADC_Start_DMA(&hadc1, (uint32_t *)adc_buffer, ADC_SAMPLES * 2 * 2);
+  HAL_ADC_Start_DMA(&hadc1, (uint32_t *)adc_buffer, 2);
 
   //  Check if the program file exists on the SD card
   // If it exists, load it into the flash memory.

--- a/Middlewares/gwtonn/include/internal_sensors.h
+++ b/Middlewares/gwtonn/include/internal_sensors.h
@@ -24,17 +24,39 @@ extern "C" {
 #endif // End of extern "C" block
 
 /**
+ * @brief  AVG Slope for temperature calculation
+ * 
+ * This value is used to calculate the temperature from the ADC value.
+ * For the STM32F4xx series, the average slope is approximately 2.5 mV/°C.
+ */
+#define AVG_SLOPE (2.5F)
+/**
+ * @brief Voltage at 25 °C
+ * 
+ * This value is used to calculate the temperature from the ADC value.
+ * For the STM32F4xx series, the voltage at 25 °C is approximately 0.76 V.
+ */
+#define V_AT_25C  (0.76F)
+/**
+ * @brief Internal reference voltage
+ * 
+ * This value is used to calculate the internal voltage from the ADC value.
+ * For the STM32F4xx series, the internal reference voltage is approximately 1.2 V.
+ */
+#define V_REF_INT (1.2F)
+
+/**
  * @brief  Get the temperature value of the STM32F4xx microcontroller
  * 
  * @retval Temperature value in Celsius
  */
-int is_get_temperature(void);
+float is_get_temperature(void);
 /**
  * @brief  Get the internal voltage of the STM32F4xx microcontroller
  *
  * @retval Internal voltage value in millivolts
  */
-int is_get_vref(void);
+float is_get_vref(void);
 /**
  * @brief  Get the date and time from the RTC
  *

--- a/Middlewares/gwtonn/src/logger.c
+++ b/Middlewares/gwtonn/src/logger.c
@@ -56,12 +56,11 @@ void logger_task(void *argument) {
 
             CLEAR_BUFFER(string);
             snprintf(
-                string, BUFFER_SIZE,
-                "[%02d:%02d:%02d],%d,%d,%d,%d,%d\n\r",
+                string, BUFFER_SIZE, "[%02d:%02d:%02d],%d,%d,%d,%d,%d\n\r",
                 gTime.Hours, gTime.Minutes, gTime.Seconds,
                 telemetry.instruction_pointer,
-                telemetry.shutdown_index_register, is_get_temperature(),
-                is_get_vref(),
+                telemetry.shutdown_index_register,
+                (uint16_t)(is_get_temperature ()* 100), (uint16_t)(is_get_vref()*100),
                 telemetry.trigger); // format the string to write to the file
 
             write_file(LOG_FILENAME "\0", string);

--- a/Middlewares/gwtonn/src/program_controller.c
+++ b/Middlewares/gwtonn/src/program_controller.c
@@ -199,8 +199,6 @@ vm_send_telemetry(
   telemetry_t telemetry = {
       program_controller_registers->instruction_pointer,
       program_controller_registers->end_program_pointer,
-      is_get_temperature(),
-      is_get_vref(),
       0,
   };
   if (osOK != osMessageQueuePut(loggerQueueHandle, &telemetry, 0, 0U))


### PR DESCRIPTION
Fixes #64

De temperatuur en vref worden nu in de log gezet als integers. Om de werkelijke waarde te weten, moet je de volgende formule gebruiken:
**temp = temperatuur / 100**